### PR TITLE
Create Contact and Speakers page and adds a experiment to the website Footer

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1005,6 +1005,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz",
+      "integrity": "sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.14.0",
     "core-js": "^3.6.5",
     "p5": "^1.0.0",
     "vue": "^2.6.11",

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -17,6 +17,7 @@
       <ContactPage/>
       <RegistrationPage/>
       <FourierBackground/>
+      <PulsarRadioBackground/>
     </v-main>
   </v-app>
 </template>
@@ -28,6 +29,7 @@ import SpeakersPage from './components/SpeakersPage'
 import ContactPage from './components/ContactPage'
 import RegistrationPage from './components/RegistrationPage'
 import FourierBackground from './components/FourierBackground'
+import PulsarRadioBackground from './components/PulsarRadioBackground'
 
 export default {
   name: 'App',
@@ -37,7 +39,8 @@ export default {
     SpeakersPage,
     ContactPage,
     RegistrationPage,
-    FourierBackground
+    FourierBackground,
+    PulsarRadioBackground
   },
   data: () => ({
     marks: {

--- a/website/src/components/ContactCard.vue
+++ b/website/src/components/ContactCard.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-card raised class="pa-10">
+    <v-icon size="60">{{contact.icon}}</v-icon>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: ['contact'],
+}
+</script>

--- a/website/src/components/ContactPage.vue
+++ b/website/src/components/ContactPage.vue
@@ -1,14 +1,32 @@
 <template>
-  <v-container id="contact-page" style="height: 100vh"></v-container>
+  <v-container id="contact-page">
+    <v-row class="d-flex justify-center my-15 roboto-mono">
+      <div class="text-h2" v-text="'Quer falar com a gente?'"></div>
+    </v-row>
+    <v-row class="d-flex justify-center">
+      <ContactCard class="ma-5" :contact="item" v-for="(item, index) in contacts" :key="index"/>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
+import ContactCard from './ContactCard'
+
 export default {
   name: 'ContactPage',
-  components: {},
+  components: {
+    ContactCard
+  },
   data: () => ({
     container: document.querySelector('#contact-page'),
-    
+    contacts: [
+      { icon: 'mdi-twitter', name: '@seccom-ufsc' },
+      { icon: 'mdi-instagram', name: '@seccom-ufsc' },
+      { icon: 'mdi-email', name: 'seccom.ufsc@gmail.com' },
+      { icon: 'mdi-github', name: 'seccom.ufsc@gmail.com' },
+      { icon: 'mdi-discord', name: 'seccom.ufsc@gmail.com' },
+      { icon: 'mdi-telegram', name: 'seccom.ufsc@gmail.com' },
+    ]
   }),
   mounted () {
     this.container = document.querySelector('#contact-page')

--- a/website/src/components/Footer.vue
+++ b/website/src/components/Footer.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-container class="pulsar-radio-canvas"></v-container>  
+</template>
+
+<script>
+import Vue from 'vue'
+import PulsarRadio from './../js/PulsarRadio.js'
+import p5 from 'p5'
+
+export default Vue.extend({
+  data () {
+    return {
+      sketch: null,
+      instance: null
+    }
+  },
+  mounted () {
+    this.sketch = function (p) {
+      const wave = new Fourier(p, 0.03, 70, '#2D78BA', 5)
+
+      p.setup = function () {
+        const canvas = p.createCanvas(window.innerWidth, window.innerHeight)
+        document.querySelector('.pulsar-radio-canvas').appendChild(canvas.elt)
+        p.frameRate(60)
+      }
+
+      p.draw = function () {
+        p.clear()
+        p.translate(p.width - 120, p.height / 2)
+        p.rotate(p.PI)
+        wave.show()
+      }
+    }
+
+    this.instance = new p5(this.sketch)
+  }
+})
+</script>
+
+<style lang="scss">
+  .fourier-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 0;
+  }
+</style>

--- a/website/src/components/PulsarRadioBackground.vue
+++ b/website/src/components/PulsarRadioBackground.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="pulsar-radio-canvas"></div>
+</template>
+
+<script>
+/* eslint-disable func-call-spacing,no-undef,no-unmodified-loop-condition */
+
+import Vue from 'vue'
+import p5 from 'p5'
+
+export default Vue.extend({
+  data () {
+    return {
+      sketch: null,
+      instance: null
+    }
+  },
+  mounted () {
+    this.sketch = function (p) {
+      let f = 0
+
+      p.setup = function () {
+        const canvas = p.createCanvas(window.innerWidth, window.innerHeight * 0.2)
+        document.querySelector('.pulsar-radio-canvas').appendChild(canvas.elt)
+        p.frameRate(60)
+      }
+
+      p.draw = function () {
+        f++
+        
+        p.background('#121212')
+        p.fill('#121212')
+        p.stroke(255) 
+
+        for (let y = 100; y < p.height; y += 5) {
+          p.beginShape()
+          let x = 0
+          for (x = 0; x < p.width; ++x) {
+            p.vertex(x, y - 80 / (1 + p.pow (x - p.width / 2, 4) / 8e6) * p.noise(x / 30 + f / 50 + y))
+          }
+          p.vertex(x, 1e4)
+          p.endShape()
+        }
+      }
+    }
+
+    this.instance = new p5(this.sketch)
+  }
+})
+</script>
+
+<style lang="scss">
+  .pulsar-radio-canvas {
+    padding: 0;
+    margin: 0;
+    // z-index: -3;
+  }
+</style>

--- a/website/src/components/SpeakerCard.vue
+++ b/website/src/components/SpeakerCard.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-card class="speaker-card">
+    <v-row class="d-flex justify-center pa-8">
+      <v-avatar size="150" rounded="circle">
+        <img :src="speaker.photo" style="object-fit: cover">
+      </v-avatar>
+    </v-row>
+    <v-card-title>{{speaker.name}}</v-card-title>
+    <v-card-subtitle>{{speaker.title}}</v-card-subtitle>
+    <v-card-text>{{speaker.text}}</v-card-text>
+  </v-card>
+</template>
+
+<script>
+import Vue from 'vue'
+
+export default Vue.extend({
+  data: function () {
+    return {}
+  },
+  props: ['speaker'],
+})
+
+</script>
+
+<style>
+  .speaker-card {
+    max-width: 300px;
+  }
+  
+  @media (max-aspect-ratio: 1/1) {
+    .speaker-card {
+      max-width: 100%;
+    }
+  }
+</style>

--- a/website/src/components/SpeakersPage.vue
+++ b/website/src/components/SpeakersPage.vue
@@ -1,13 +1,28 @@
 <template>
-  <v-container id="speakers-page" style="height: 100vh"></v-container>
+  <v-container id="speakers-page">
+    <v-row class="d-flex justify-space-between">
+      <SpeakerCard class="ma-4" v-for="(speaker, index) in speakers" :key="index" :speaker="speaker"/>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
+import SpeakerCard from './SpeakerCard'
+
 export default {
   name: 'SpeakersPage',
-  components: {},
+  components: {
+    SpeakerCard
+  },
   data: () => ({
     container: document.querySelector('#speakers-page'),
+    speakers: [
+      { name: 'Velho do Shutterstock', title: 'Analista de Dados', text: 'Cillum dolor ipsum sit laborum elit do ut labore. Esse officia velit quis quis in culpa quis dolore sunt velit. Aute cupidatat officia occaecat sint minim aliqua incididunt aliqua.', photo: 'https://image.shutterstock.com/z/stock-photo-portrait-of-happy-old-man-smiling-looking-at-camera-75633424.jpg' },
+      { name: 'Velho do Shutterstock', title: 'Analista de Dados', text: 'Reprehenderit nisi aliquip laborum ullamco aute irure aliqua incididunt officia est laboris. Commodo culpa duis proident aliquip et non. Officia velit veniam nisi mollit velit commodo consectetur veniam ex proident eiusmod aliquip.', photo: 'https://image.shutterstock.com/z/stock-photo-portrait-of-happy-old-man-smiling-looking-at-camera-75633424.jpg' },
+      { name: 'Velho do Shutterstock', title: 'Analista de Dados', text: 'Sit deserunt irure labore ea et aliqua anim id. Adipisicing officia consectetur ullamco id minim sunt aliquip incididunt pariatur sunt enim veniam sint. Dolore adipisicing ipsum ut amet deserunt.', photo: 'https://image.shutterstock.com/z/stock-photo-portrait-of-happy-old-man-smiling-looking-at-camera-75633424.jpg' },
+      { name: 'Velho do Shutterstock', title: 'Analista de Dados', text: 'Ullamco id cillum proident Lorem mollit. Dolore cupidatat adipisicing incididunt ex duis. Officia id irure ad cupidatat elit.', photo: 'https://image.shutterstock.com/z/stock-photo-portrait-of-happy-old-man-smiling-looking-at-camera-75633424.jpg' },
+      { name: 'Velho do Shutterstock', title: 'Analista de Dados', text: 'Ipsum amet consectetur ex velit anim ipsum aute tempor dolore. Incididunt aliqua sit consectetur ut mollit et consectetur occaecat sunt aliqua mollit pariatur anim. Eiusmod duis velit laboris ullamco adipisicing deserunt ad mollit proident ullamco nulla quis consectetur labore.', photo: 'https://image.shutterstock.com/z/stock-photo-portrait-of-happy-old-man-smiling-looking-at-camera-75633424.jpg' },
+    ]
   }),
   mounted () {
     this.container = document.querySelector('#speakers-page')
@@ -15,7 +30,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang='scss'>
   .blue-text-must-click {
     color: #2D78BA;
   }

--- a/website/src/components/StartPage.vue
+++ b/website/src/components/StartPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container id="start-page" style="height: 100vh">
+  <v-container id="start-page">
     <v-col class="d-flex align-center flex-column" style="height: 90vh">
       <v-row class="d-flex align-center mobile-flex-column">
         <div class="text-h1 roboto-mono" v-text="'SECCOM'"></div>

--- a/website/src/plugins/vuetify.js
+++ b/website/src/plugins/vuetify.js
@@ -1,11 +1,15 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify/lib'
+import '@fortawesome/fontawesome-free/css/all.css'
 
 import colors from 'vuetify/lib/util/colors'
 
 Vue.use(Vuetify)
 
 export default new Vuetify({
+  icons: {
+    iconfont: 'fa'
+  },
   theme: {
     dark: true,
     themes: {


### PR DESCRIPTION
This PR just creates the UI for Speakers and Contact pages

- Still using mocked data for speakers
- Contact info not provided yet

The footer canvas probably will be changed to another mathematical visualization consistent with the event's theme.